### PR TITLE
go back to having a smaller sidebar

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -385,11 +385,12 @@ body {
 
 /* mainmatter specific stuff */
 .reveal .controls {
-  color: black
+  color: black;
+  right: calc(30px + var(--r-controls-spacing));
 }
 
 .backgrounds .slide-background-content {
-  box-shadow: inset -120px 0 #6200ee;
+  box-shadow: inset -30px 0 #6200ee;
 }
 
 .blur-background .slide-background-content {


### PR DESCRIPTION
Originally I made the sidebar a lot wider so the controls were full encapsulated in it, but actually that had a risk of overlapping the content. So I just pushed the controls fully outside the sidebar to make it not overlap in an odd way