### PR TITLE
add an editorconfig to prevent incorrect spacing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.{diff,md}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
https://github.com/mainmatter/auto-reveal-theme-mainmatter/pull/17 has a conflict because of tabs vs spaces in the package.json 😭 this tries to prevent that 